### PR TITLE
Add dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./crmapp.js": "./dist/src/crmapp.js"
   },
   "scripts": {
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",


### PR DESCRIPTION
Add a dev script that mirrors the start script functionality for better development workflow consistency. This allows developers to use either npm run dev or npm start to launch the development environment.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=mystic-garden&projectId=51bd2116b5e94e4684f5a75e24859c3f)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>51bd2116b5e94e4684f5a75e24859c3f</projectId>-->